### PR TITLE
pull job info from systemd via d-bus as it fits better for the concept

### DIFF
--- a/PKGBUILD.in
+++ b/PKGBUILD.in
@@ -37,7 +37,7 @@ build() {
 	install -d MANSBUILD_sge/SEDMAN/man/man5
 	install -d MANSBUILD_sge/SEDMAN/man/man8
 	sh scripts/bootstrap.sh -no-java -no-jni
-	./aimk -DGIT_REPO_VERSION=\\\"$pkgver\\\" -no-java -no-jni -with-arch-linux
+	./aimk -DGIT_REPO_VERSION=\\\"$pkgver\\\" -no-java -no-jni -with-arch-linux -systemd
 	install -d clients/gui-installer/dist
 	touch clients/gui-installer/dist/installer.jar
 	rm -f LINUXAMD64/config.status

--- a/source/aimk
+++ b/source/aimk
@@ -233,6 +233,7 @@ usage:
    echo "-purify           -> instrument code with purify (implies -debug)"
    echo "-qmake            -> use qmake instead of make"
    echo "-shared-libs      -> create libraries as shared libs"
+   echo "-systemd	   -> enable job stats directly via SystemD D-BUS (needs SystemD version >=222)"
    echo "-spool-berkeleydb -> use berkeleydb spooling"
    echo "-spool-classic    -> use classic flatfile spooling"
    echo "-spool-targets    -> only create qmaster, spooldefaults and spoolinit"
@@ -842,6 +843,10 @@ while ($#argv >= 1 && $?found)
       set SPOOLING_METHOD = "classic"
       set SPOOLING_LIBS   = "-lspoolloader -lspoolc -lspool"
       set SPOOLING_DEPS   = "spoolloaderlib spoolclib spoollib"
+      breaksw
+   case "-systemd":
+      set DLLIB = "$DLLIB -lsystemd"
+      set CFLAGS = "$CFLAGS -DHAVE_SYSTEMD=1"
       breaksw
    case "-classic-targets":   
       set CORE   = 1


### PR DESCRIPTION
Currently we get info about jobs (see qstat/qacct) spawned via SystemD using cgroups.
This is not very flexible as newer versions of SystemD use cgroups_v2 where our code fails.
This fix makes SGE to connect to SystemD on exec hosts via D-bus to obtain the requested properties.
Should work with SystemD version 222 onward (regardless of cgroup backend being used). Unfortunately fails on RHEL-7 as systemd is too old here.
Tested on RHEL-8 and Fedora-34