### PR TITLE
changing administrative status for new hosts in cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,13 @@ chown -R sge /opt/sge
 cd /opt/sge
 yes "" | ./install_qmaster
 source /opt/sge/default/common/settings.sh
-qconf -ah exec-node
-qconf -as exec-node
+```
+Next commands it's necessary to run for each nodes in cluster:
+```
+qconf -ah node-01
+qconf -ah node-02
+...
+qconf -ah node-0N
 ```
 
 #### The third - on all nodes as root

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ chown -R sge /opt/sge
 cd /opt/sge
 yes "" | ./install_qmaster
 source /opt/sge/default/common/settings.sh
+qconf -as master
 ```
 Next commands it's necessary to run for each nodes in cluster:
 ```


### PR DESCRIPTION
I deleted `qconf -as node-XX` because it changes opportunity to submit new tasks from execution host. I think it isn't necessary on first installation steps.