### PR TITLE
Fix bad pkgver error on Arch Linux

### DIFF
--- a/PKGBUILD.in
+++ b/PKGBUILD.in
@@ -3,7 +3,7 @@ pkgname=sge
 pkgver=SKIP
 pkgver() {
 	cd ..
-	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git describe  --always --dirty=.dirty)"
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git describe  --always --dirty=.dirty)" | sed 's/-/./g'
 }
 pkgrel=1
 pkgdesc="Son of Grid Engine/Sun Grid Engine"


### PR DESCRIPTION
`makepkg` doesn't accept the current `pkgver` string:

```
$ makepkg   
==> Making package: sge SKIP-1 (Thu 19 Oct 2023 07:19:12 PM EDT)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
==> Extracting sources...
==> Starting prepare()...
==> Starting pkgver()...
==> ERROR: pkgver is not allowed to contain colons, forward slashes, hyphens or whitespace.
==> ERROR: pkgver() generated an invalid version: r151.8.1.9-140-gcecd9e6
```

So this patch just replaces the hyphens in the version string with dots.