### PR TITLE
revert default value to y when auto installation

### DIFF
--- a/source/dist/util/install_modules/inst_common.sh
+++ b/source/dist/util/install_modules/inst_common.sh
@@ -1480,9 +1480,9 @@ CheckWhoInstallsSGE()
              "   - Grid Engine still has to be started by user >root<\n\n" \
              "   - this directory should be owned by the Grid Engine administrator\n"
 
-   $INFOTEXT -auto $AUTO -ask "y" "n" -def "n" -n \
+   $INFOTEXT -auto $AUTO -ask "y" "n" -def "y" -n \
              "Do you want to install Grid Engine\n" \
-             "under a user ID other than >root< (y/n) [n] >> "
+             "under a user ID other than >root< (y/n) [y] >> "
 
    if [ $? = 0 ]; then
       done=false


### PR DESCRIPTION
When we install sge by using auto method `./inst_sge -m -auto installation.conf`,the `ADMIN_USER` variable is not working.

To fix this issue,the code reverted to the previous version with the default value to `y`.

